### PR TITLE
Add clarification that Request and Response are available on the exce…

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -518,7 +518,10 @@ If a request exceeds the configured number of maximum redirections, a
 :exc:`~requests.exceptions.TooManyRedirects` exception is raised.
 
 All exceptions that Requests explicitly raises inherit from
-:exc:`requests.exceptions.RequestException`.
+:exc:`requests.exceptions.RequestException`. This means that the 
+:class:`Request <requests.Request>` and :class:`Response <requests.Response>` 
+objects are available on the exception as ``request`` and ``response`` 
+respectively.
 
 -----------------------
 


### PR DESCRIPTION
…ption object.

This came up at work with a senior developer who is just now learning Python. He was complaining that he couldn't get the status code off an exception, but it's there obviously. Anyway, I think this makes it clearer that there is more information in the exception than may be initially obvious without reading the code.
